### PR TITLE
Fix creating zip archive

### DIFF
--- a/app/code/community/DPD/Shipping/Model/Adminhtml/Dpdgrid.php
+++ b/app/code/community/DPD/Shipping/Model/Adminhtml/Dpdgrid.php
@@ -215,7 +215,7 @@ class DPD_Shipping_Model_Adminhtml_Dpdgrid extends Mage_Core_Model_Abstract
         }
         if (count($valid_files)) {
             $zip = new ZipArchive();
-            if ($zip->open($destination, $overwrite ? ZIPARCHIVE::OVERWRITE : ZIPARCHIVE::CREATE) !== true) {
+            if ($zip->open($destination, $overwrite ? ZIPARCHIVE::OVERWRITE | ZIPARCHIVE::CREATE : ZIPARCHIVE::CREATE) !== true) {
                 return false;
             }
             foreach ($valid_files as $file) {


### PR DESCRIPTION
ZIPARCHIVE::open with ZIPARCHIVE::OVERWRITE does not create a file if it does not exist. Using ZIPARCHIVE::OVERWRITE | ZIPARCHIVE::CREATE to overwrite the file if it exists, and to create it otherwise.