### PR TITLE
Crucial updates to Google Geocode API integration and DPD webservice WSDL URL's

### DIFF
--- a/app/code/community/DPD/Shipping/Block/Carrier/Parcelshop.php
+++ b/app/code/community/DPD/Shipping/Block/Carrier/Parcelshop.php
@@ -247,7 +247,7 @@ class DPD_Shipping_Block_Carrier_Parcelshop extends Mage_Core_Block_Template
             <table>
             <tbody>';
             foreach ($shop->openingHours as $openinghours) {
-                $html .= '<tr><td style="padding-right:10px;"><strong>' . $openinghours->weekday . '</strong></td><td style="padding-right:10px;">' . $openinghours->openMorning . ' - ' . $openinghours->closeMorning . '
+                $html .= '<tr><td style="padding-right:10px;"><strong>' . Mage::helper('dpd')->__($openinghours->weekday) . '</strong></td><td style="padding-right:10px;">' . $openinghours->openMorning . ' - ' . $openinghours->closeMorning . '
             </td><td>' . $openinghours->openAfternoon . ' - ' . $openinghours->closeAfternoon . '</td></tr>';
             }
             $html .= '</tbody>
@@ -261,7 +261,7 @@ class DPD_Shipping_Block_Carrier_Parcelshop extends Mage_Core_Block_Template
             <tbody>';
             foreach (Mage::helper('core')->jsonDecode($shop->getParcelshopOpeninghours()) as $openinghours) {
 
-                $html .= '<tr><td style="padding-right:10px;"><strong>' . $openinghours['weekday'] . '</strong></td><td style="padding-right:10px;">' . $openinghours['openMorning'] . ' - ' . $openinghours['closeMorning'] . '
+                $html .= '<tr><td style="padding-right:10px;"><strong>' . Mage::helper('dpd')->__($openinghours['weekday']) . '</strong></td><td style="padding-right:10px;">' . $openinghours['openMorning'] . ' - ' . $openinghours['closeMorning'] . '
             </td><td>' . $openinghours['openAfternoon'] . ' - ' . $openinghours['closeAfternoon'] . '</td></tr>';
             }
             $html .= '</tbody>

--- a/app/code/community/DPD/Shipping/Helper/Data.php
+++ b/app/code/community/DPD/Shipping/Helper/Data.php
@@ -92,6 +92,19 @@ class DPD_Shipping_Helper_Data extends Mage_Core_Helper_Abstract
         $url = 'https://maps.googleapis.com/maps/api/geocode/json?key=' . Mage::getStoreConfig('carriers/dpdparcelshops/google_maps_api') . '&components=' . urlencode($addressToInsert);
         $source = file_get_contents($url);
         $obj = json_decode($source);
+
+        if (!property_exists($obj, 'results') || (property_exists($obj, 'results') && !$obj->results)) {
+            Mage::log(
+                sprintf(
+                    'DPD Shipping - Determining Google maps center failed. %s',
+                    json_encode(
+                        array('Requested URL' => $url, 'Response' => $source)
+                    )
+                )
+            );
+            return '0,0';
+        }
+
         $LATITUDE = $obj->results[0]->geometry->location->lat;
         $LONGITUDE = $obj->results[0]->geometry->location->lng;
         return $LATITUDE . ',' . $LONGITUDE;

--- a/app/code/community/DPD/Shipping/Helper/Data.php
+++ b/app/code/community/DPD/Shipping/Helper/Data.php
@@ -89,7 +89,7 @@ class DPD_Shipping_Helper_Data extends Mage_Core_Helper_Abstract
             //$addressToInsert .= $address->getStreet(2) . " ";
         //}
         $addressToInsert = "postal_code:" .$address->getPostcode() . "|" . "country:" . $address->getCountry();
-        $url = 'http://maps.googleapis.com/maps/api/geocode/json?&components=' . urlencode($addressToInsert);
+        $url = 'https://maps.googleapis.com/maps/api/geocode/json?key=' . Mage::getStoreConfig('carriers/dpdparcelshops/google_maps_api') . '&components=' . urlencode($addressToInsert);
         $source = file_get_contents($url);
         $obj = json_decode($source);
         $LATITUDE = $obj->results[0]->geometry->location->lat;

--- a/app/code/community/DPD/Shipping/Model/Webservice.php
+++ b/app/code/community/DPD/Shipping/Model/Webservice.php
@@ -31,17 +31,17 @@ class DPD_Shipping_Model_Webservice extends Mage_Core_Model_Abstract
     /**
      * Path to login webservice wsdl.
      */
-    CONST WEBSERVICE_LOGIN = 'LoginService.svc?singleWsdl';
+    CONST WEBSERVICE_LOGIN = 'LoginService/V2_0/?wsdl';
 
     /**
      * Path to ParcelShopFinder webservice wsdl.
      */
-    CONST WEBSERVICE_PARCELSHOP = 'ParcelShopFinderService.svc?singleWsdl';
+    CONST WEBSERVICE_PARCELSHOP = 'ParcelShopFinderService/V3_0/?wsdl';
 
     /**
      * Path to Shipment webservice wsdl.
      */
-    CONST WEBSERVICE_SHIPMENT = 'ShipmentService.svc?singleWsdl';
+    CONST WEBSERVICE_SHIPMENT = 'ShipmentService/V2_0/?wsdl';
 
     /**
      * Product type for shipmentservice, should be always 'CL' as instructed by DPD.

--- a/app/code/community/DPD/Shipping/etc/config.xml
+++ b/app/code/community/DPD/Shipping/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <DPD_Shipping>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
         </DPD_Shipping>
     </modules>
     <global>

--- a/app/code/community/DPD/Shipping/etc/system.xml
+++ b/app/code/community/DPD/Shipping/etc/system.xml
@@ -383,7 +383,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <comment><![CDATA[<a href="https://developers.google.com/maps/documentation/javascript/tutorial?hl=nl#api_key" target="_blank">How to request an API key</a>]]></comment>
+                            <comment><![CDATA[<a href="https://developers.google.com/maps/documentation/javascript/get-api-key?hl=nl" target="_blank">How to request an API key</a>. Required API's to be activated: <a href="https://developers.google.com/maps/documentation/javascript/tutorial" target="_blank">Maps JavaScript API</a> and <a href="https://developers.google.com/maps/documentation/geocoding/start" target="_blank">Geocoding API</a>.]]></comment>
                         </google_maps_api>
                         <google_maps_width translate="label">
                             <label>Map width</label>

--- a/js/dpd/shipping.js
+++ b/js/dpd/shipping.js
@@ -65,7 +65,7 @@ DPD.Shipping = Class.create({
         if (this.config.gmapsDisplay && !dialog) {
             showDPDWindow(this.config.windowParcelUrl + "?windowed=true",
                 'iframe',
-                (parseInt(this.config.gmapsWidth.replace("px", "")) + 40), (parseInt(this.config.gmapsHeight.replace("px", "")) + 40),
+                parseInt(this.config.gmapsWidth.replace("px", "")), parseInt(this.config.gmapsHeight.replace("px", "")),
                 this.config
             );
         }
@@ -194,7 +194,7 @@ DPD.Shipping = Class.create({
             this.container.down('#s_method_dpdparcelshops_dpdparcelshops').checked = true;
             showDPDWindow(this.config.windowParcelUrl + "?windowed=true",
                 'iframe',
-                (parseInt(this.config.gmapsWidth.replace("px", "")) + 40), (parseInt(this.config.gmapsHeight.replace("px", "")) + 40),
+                parseInt(this.config.gmapsWidth.replace("px", "")), parseInt(this.config.gmapsHeight.replace("px", "")),
                 this.config
             );
         }


### PR DESCRIPTION
Commits within the pull request contain following required updates to get the module running (using Magento 1.x):
* Updated the Google Geocoding integration to meet recent requirements by Google. Earlier integration is broken / does not center the Google map upon checkout.
* Updated Google API key generation instructions, mentioned when configuring the shipping method, as well.
* Corrected the DPD webservice WSDL URL's / endpoints to the actually working paths (those currently mentioned within the master branch return 404 pages).